### PR TITLE
feat: 0.2.0 version release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const nurekit = new Nurekit()
 
 ## Contributing
 
-If you want to contribute to improving the project, firstly read [CONTIRBUTING.md](https://github.com/OneLiL05/nurekit/blob/main/CONTIRBUTING.md)
+If you want to contribute to improving the project, firstly read [CONTIRBUTING.md](https://github.com/OneLiL05/nurekit/blob/main/CONTRIBUTING.md)
 
 ## Methods
 
@@ -55,7 +55,7 @@ import { Nurekit } from "@nurejs/api"
 
 const nurekit = new Nurekit()
 
-const auditories = await nurekit.auditoriums.findOne({ name: "285" })
+const auditories = await nurekit.auditoriums.findOne("285")
 ```
 
 **Input:**
@@ -107,7 +107,7 @@ import { Nurekit } from "@nurejs/api"
 
 const nurekit = new Nurekit()
 
-const groups = await nurekit.groups.findOne({ name: "пзпі-23-5" })
+const groups = await nurekit.groups.findOne("пзпі-23-5")
 ```
 
 **Input:**
@@ -162,15 +162,13 @@ import { Nurekit } from "@nurejs/api"
 
 const nurekit = new Nurekit()
 
-const teachers = await nurekit.teachers.findOne({ shortName: "Боцюра О. А." })
+const teachers = await nurekit.teachers.findOne("Боцюра О. А.")
 ```
 
 **Input:**
 
 ```ts
-{
-  shortName: string;
-}
+shortName: string;
 ```
 
 **Output:**

--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ const nurekit = new Nurekit()
 
 const schedule = await nurekit.groups.getSchedule({
   groupName: "пзпі-23-5",
-  startTime: 1693170000,
-  endTime: 1694811599,
+  startTime: "2023-09-11",
+  endTime: "2023-09-15",
 });
 ```
 
@@ -206,8 +206,8 @@ const schedule = await nurekit.groups.getSchedule({
 ```ts
 {
   groupName: string,
-  startTime: number,
-  endTime: number,
+  startTime: string,
+  endTime: string,
 }
 ```
 

--- a/src/helpers/date.helper.ts
+++ b/src/helpers/date.helper.ts
@@ -1,0 +1,5 @@
+export function toTimestamp(stringDate: string) {
+	const parsedDate = Date.parse(stringDate);
+
+	return parsedDate / 1000;
+}

--- a/src/modules/auditoriums.module.ts
+++ b/src/modules/auditoriums.module.ts
@@ -2,10 +2,6 @@ import { handleAxiosError } from "../helpers/axios.helper.js";
 import { axiosClient } from "../libs/axios.js";
 import { IAuditorium } from "../types/index.js";
 
-interface FindOneParams {
-	name: string;
-}
-
 export class AuditoriumsModule {
 	/**
 	 * Method returns array of objects with such fields:
@@ -52,7 +48,7 @@ export class AuditoriumsModule {
 	 *
 	 * @publicApi
 	 */
-	public async findOne({ name }: FindOneParams): Promise<IAuditorium> {
+	public async findOne(name: string): Promise<IAuditorium> {
 		const auditoriums = await this.findMany();
 
 		const auditorium = auditoriums.find(

--- a/src/modules/auditoriums.module.ts
+++ b/src/modules/auditoriums.module.ts
@@ -7,6 +7,24 @@ interface FindOneParams {
 }
 
 export class AuditoriumsModule {
+	/**
+	 * Method returns array of objects with such fields:
+	 * ```typescript
+	 * {
+	 *   id: number;
+	 *   name: string;
+	 * }
+	 * ```
+	 *
+	 * Example usage:
+	 * ```typescript
+	 const auditoriums = await nurekit.auditoriums.findMany()
+	 * ```
+	 *
+	 * @see [Docs](https://github.com/OneLiL05/nurekit#get-auditoriums)
+	 *
+	 * @publicApi
+	 */
 	public async findMany(): Promise<IAuditorium[]> {
 		return axiosClient
 			.get<IAuditorium[]>("/api/auditories")
@@ -14,6 +32,26 @@ export class AuditoriumsModule {
 			.catch(handleAxiosError);
 	}
 
+	/**
+	 * Method returns object with such fields:
+	 * ```typescript
+	 * {
+	 *   id: number;
+	 *   name: string;
+	 * }
+	 * ```
+	 *
+	 * Example usage:
+	 * ```typescript
+	 const auditorium = await nurekit.auditoriums.findOne({ name: "285" })
+	 * ```
+	 *
+	 * @param name name of auditorium you want to get info about
+	 *
+	 * @see [Docs](https://github.com/OneLiL05/nurekit#get-auditorium)
+	 *
+	 * @publicApi
+	 */
 	public async findOne({ name }: FindOneParams): Promise<IAuditorium> {
 		const auditoriums = await this.findMany();
 

--- a/src/modules/groups.module.ts
+++ b/src/modules/groups.module.ts
@@ -14,6 +14,24 @@ interface GetScheduleParams {
 }
 
 export class GroupsModule {
+	/**
+	 * Method returns array of objects with such fields:
+	 * ```typescript
+	 * {
+	 *   id: number;
+	 *   name: string;
+	 * }
+	 * ```
+	 *
+	 * Example usage:
+	 * ```typescript
+	 const group = await nurekit.groups.findMany()
+	 * ```
+	 *
+	 * @see [Docs](https://github.com/OneLiL05/nurekit#get-groups)
+	 *
+	 * @publicApi
+	 */
 	public async findMany(): Promise<IGroup[]> {
 		return axiosClient
 			.get<IGroup[]>("/api/groups")
@@ -21,6 +39,26 @@ export class GroupsModule {
 			.catch(handleAxiosError);
 	}
 
+	/**
+	 * Method returns object with such fields:
+	 * ```typescript
+	 * {
+	 *   id: number;
+	 *   name: string;
+	 * }
+	 * ```
+	 *
+	 * Example usage:
+	 * ```typescript
+	 const group = await nurekit.groups.findOne({ name: "пзпі-23-5" })
+	 * ```
+	 *
+	 * @param name name of group you want to get info about
+	 *
+	 * @see [Docs](https://github.com/OneLiL05/nurekit#get-a-group)
+	 *
+	 * @publicApi
+	 */
 	public async findOne({ name }: FindOneParams): Promise<IGroup> {
 		const groups = await this.findMany();
 
@@ -33,6 +71,32 @@ export class GroupsModule {
 		return group;
 	}
 
+	/**
+	 * Method returns schedule:
+	 * ```typescript
+	 * {
+	 *   id: number;
+	 *   name: string;
+	 * }
+	 * ```
+	 *
+	 * Example usage:
+	 * ```typescript
+	 const schedule = await nurekit.groups.getSchedule({
+  	  groupName: "пзпі-23-5",
+  	  startTime: 1693170000,
+  	  endTime: 1694811599,
+	});
+	 * ```
+	 *
+	 * @param groupName name of group you want to get schedule for
+	 * @param startTime
+	 * @param endTime
+	 *
+	 * @see [Docs](https://github.com/OneLiL05/nurekit#get-schedule)
+	 *
+	 * @publicApi
+	 */
 	public async getSchedule({
 		groupName,
 		startTime,

--- a/src/modules/groups.module.ts
+++ b/src/modules/groups.module.ts
@@ -1,4 +1,5 @@
 import { handleAxiosError } from "../helpers/axios.helper.js";
+import { toTimestamp } from "../helpers/date.helper.js";
 import { transformSchedule } from "../helpers/schedule.helper.js";
 import { IGroup, IRawSchedule, ISchedule } from "../index.js";
 import { axiosClient } from "../libs/axios.js";
@@ -9,8 +10,8 @@ interface FindOneParams {
 
 interface GetScheduleParams {
 	groupName: string;
-	startTime: number;
-	endTime: number;
+	startTime: string;
+	endTime: string;
 }
 
 export class GroupsModule {
@@ -84,8 +85,8 @@ export class GroupsModule {
 	 * ```typescript
 	 const schedule = await nurekit.groups.getSchedule({
   	  groupName: "пзпі-23-5",
-  	  startTime: 1693170000,
-  	  endTime: 1694811599,
+  	  startTime: "2023-09-11",
+  	  endTime: "2023-09-15",
 	});
 	 * ```
 	 *
@@ -104,9 +105,12 @@ export class GroupsModule {
 	}: GetScheduleParams): Promise<ISchedule[]> {
 		const { id: groupId } = await this.findOne({ name: groupName });
 
+		const startTimestamp = toTimestamp(startTime);
+		const endTimestamp = toTimestamp(endTime);
+
 		const rawSchedule = await axiosClient
 			.get<IRawSchedule[]>(
-				`/api/schedule?type=group&id=${groupId}&start_time=${startTime}&end_time=${endTime}`,
+				`/api/schedule?type=group&id=${groupId}&start_time=${startTimestamp}&end_time=${endTimestamp}`,
 			)
 			.then((res) => res.data)
 			.catch(handleAxiosError);

--- a/src/modules/groups.module.ts
+++ b/src/modules/groups.module.ts
@@ -4,10 +4,6 @@ import { transformSchedule } from "../helpers/schedule.helper.js";
 import { IGroup, IRawSchedule, ISchedule } from "../index.js";
 import { axiosClient } from "../libs/axios.js";
 
-interface FindOneParams {
-	name: string;
-}
-
 interface GetScheduleParams {
 	groupName: string;
 	startTime: string;
@@ -51,7 +47,7 @@ export class GroupsModule {
 	 *
 	 * Example usage:
 	 * ```typescript
-	 const group = await nurekit.groups.findOne({ name: "пзпі-23-5" })
+	 const group = await nurekit.groups.findOne("пзпі-23-5")
 	 * ```
 	 *
 	 * @param name name of group you want to get info about
@@ -60,7 +56,7 @@ export class GroupsModule {
 	 *
 	 * @publicApi
 	 */
-	public async findOne({ name }: FindOneParams): Promise<IGroup> {
+	public async findOne(name: string): Promise<IGroup> {
 		const groups = await this.findMany();
 
 		const group = groups.find((group) => group.name === name.toUpperCase());
@@ -75,10 +71,29 @@ export class GroupsModule {
 	/**
 	 * Method returns schedule:
 	 * ```typescript
-	 * {
-	 *   id: number;
-	 *   name: string;
-	 * }
+	 *{
+	 *  id: number;
+	 *  startTime: number;
+	 *  endTime: number;
+	 *  auditorium: string;
+	 *  numberPair: number;
+	 *  type: string;
+	 *  updatedAt: Date;
+	 *  groups: {
+	 *    id: number;
+	 *    name: string;
+	 *  }[];
+	 *  teachers: {
+	 *    id: number;
+	 *    fullName: string;
+	 *    shortName: string;
+	 *  }[];
+	 *  subject: {
+	 *    id: number;
+	 *    brief: string;
+	 *    title: string;
+	 *  };
+	 *}[]
 	 * ```
 	 *
 	 * Example usage:
@@ -103,7 +118,7 @@ export class GroupsModule {
 		startTime,
 		endTime,
 	}: GetScheduleParams): Promise<ISchedule[]> {
-		const { id: groupId } = await this.findOne({ name: groupName });
+		const { id: groupId } = await this.findOne(groupName);
 
 		const startTimestamp = toTimestamp(startTime);
 		const endTimestamp = toTimestamp(endTime);

--- a/src/modules/teachers.module.ts
+++ b/src/modules/teachers.module.ts
@@ -3,10 +3,6 @@ import { transformTeachers } from "../helpers/teachers.helper.js";
 import { axiosClient } from "../libs/axios.js";
 import { IRawTeacher, ITeacher } from "../types/index.js";
 
-interface FindOneParams {
-	shortName: string;
-}
-
 export class TeachersModule {
 	/**
 	 * Method returns array of objects with such fields:
@@ -50,7 +46,7 @@ export class TeachersModule {
 	 *
 	 * Example usage:
 	 * ```typescript
-	 const teacher = await nurekit.teachers.findOne({ shortName: "Боцюра О. А." })
+	 const teacher = await nurekit.teachers.findOne("Боцюра О. А.")
 	 * ```
 	 *
 	 * @param shortName short name of teacher you want to get info about
@@ -59,7 +55,7 @@ export class TeachersModule {
 	 *
 	 * @publicApi
 	 */
-	public async findOne({ shortName }: FindOneParams): Promise<ITeacher> {
+	public async findOne(shortName: string): Promise<ITeacher> {
 		const teachers = await this.findMany();
 
 		const teacher = teachers.find((teacher) => {

--- a/src/modules/teachers.module.ts
+++ b/src/modules/teachers.module.ts
@@ -8,6 +8,25 @@ interface FindOneParams {
 }
 
 export class TeachersModule {
+	/**
+	 * Method returns array of objects with such fields:
+	 * ```typescript
+	 * {
+	 *   id: number;
+	 *   fullName: string;
+	 *   shortName: string;
+	 * }
+	 * ```
+	 *
+	 * Example usage:
+	 * ```typescript
+	 const teachers = await nurekit.teachers.findMany()
+	 * ```
+	 *
+	 * @see [Docs](https://github.com/OneLiL05/nurekit#get-teachers)
+	 *
+	 * @publicApi
+	 */
 	public async findMany(): Promise<ITeacher[]> {
 		const rawTeachers = await axiosClient
 			.get<IRawTeacher[]>("/api/teachers")
@@ -19,6 +38,27 @@ export class TeachersModule {
 		return result;
 	}
 
+	/**
+	 * Method returns object with such fields:
+	 * ```typescript
+	 * {
+	 *   id: number;
+	 *   fullName: string;
+	 *   shortName: string;
+	 * }
+	 * ```
+	 *
+	 * Example usage:
+	 * ```typescript
+	 const teacher = await nurekit.teachers.findOne({ shortName: "Боцюра О. А." })
+	 * ```
+	 *
+	 * @param shortName short name of teacher you want to get info about
+	 *
+	 * @see [Docs](https://github.com/OneLiL05/nurekit#get-teachers	)
+	 *
+	 * @publicApi
+	 */
 	public async findOne({ shortName }: FindOneParams): Promise<ITeacher> {
 		const teachers = await this.findMany();
 


### PR DESCRIPTION
### New features

#### Simplified work with dates in `getSchedule` method

From now, instead of providing timestamp to 'startTime' and 'endTime' parameters, you can use string. For example:

```ts
/// Before
const schedule = await nurekit.groups.getSchedule({
  groupName: "пзпі-23-5",
  startTime: 1693170000,
  endTime: 1694811599,
});

// After
const schedule = await nurekit.groups.getSchedule({
  groupName: "пзпі-23-5",
  startTime: "2023-09-11",
  endTime: "2023-09-15",
});
```

### Code comments that will increase developer experience

From now, you don't more need to always check documentation to know how one or another method works, thanks to comments you will get tips and short doc about every method right from your code editor

### Fixes

### Simplified `findOne` method

Thanks to the @bluin4308's suggestion, you don't more need to provide object with `name` or `shortName` fields to `findOne` method parameters, just use string. For example:

```ts
// Before
const auditorium = await nurekit.auditoriums.findOne({ name: "285" })


// After
const auditorium = await nurekit.auditoriums.findOne("285")
```

